### PR TITLE
When an Android app doesn't have the INTERNET permission, getHeaderFields() returns null resulting in NPE

### DIFF
--- a/src/main/java/com/github/nkzawa/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/transports/PollingXHR.java
@@ -202,14 +202,14 @@ public class PollingXHR extends Polling {
 
                         Map<String, String> headers = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 
-                        xhrHeaderFields = xhr.getHeaderFields();
+                        Map<String, List<String>> xhrHeaderFields = xhr.getHeaderFields();
                         if(xhrHeaderFields != null) {
                             for (String key : xhrHeaderFields.keySet()) {
                                 if (key == null) continue;
                                 headers.put(key, xhr.getHeaderField(key));
                             }
                         }
-                        
+
                         self.onResponseHeaders(headers);
 
                         final int statusCode = xhr.getResponseCode();


### PR DESCRIPTION
I am testing a new app that didn't have the internet permission. I debugged it and ran in to xhr.getHeaderFields() returning a null; which led to an NPE.

I added a check for null to make the permission error a bit more transparent. Now an access denied error will propagate up instead of just a silent failure since the finally block basically throws the NPE away.
