### PR TITLE
NullPointException, in PollingXHR$Request.create()

### DIFF
--- a/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
@@ -219,6 +219,9 @@ public class PollingXHR extends Polling {
                         }
                     } catch (IOException e) {
                         self.onError(e);
+                    } catch (NullPointerException e) {
+                        // It would occur to disconnect
+                        self.onError(e);
                     } finally {
                         try {
                             if (output != null) output.close();


### PR DESCRIPTION
I got some error report, in Android-app.

```
java.lang.NullPointerException
       at java.net.NetworkInterface.getNetworkInterfacesList(NetworkInterface.java:304)
       at java.net.NetworkInterface.getByInetAddress(NetworkInterface.java:264)
       at com.android.okhttp.internal.Platform.getMtu(Platform.java:138)
       at com.android.okhttp.Connection.connect(Connection.java:959)
       at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:405)
       at com.android.okhttp.internal.http.HttpEngine.sendSocketRequest(HttpEngine.java:343)
       at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:289)
       at com.android.okhttp.internal.http.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:345)
       at com.android.okhttp.internal.http.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:296)
       at com.android.okhttp.internal.http.HttpURLConnectionImpl.getHeaderFields(HttpURLConnectionImpl.java:160)
       at com.android.okhttp.internal.http.HttpsURLConnectionImpl.getHeaderFields(HttpsURLConnectionImpl.java:214)
       at com.github.nkzawa.engineio.client.transports.PollingXHR$Request$1.run(PollingXHR.java:210)
       at java.lang.Thread.run(Thread.java:841)
```

or

```
java.lang.NullPointerException
       at java.net.NetworkInterface.getNetworkInterfacesList(NetworkInterface.java:304)
       at java.net.NetworkInterface.getByInetAddress(NetworkInterface.java:264)
       at com.android.okhttp.internal.Platform.getMtu(Platform.java:138)
       at com.android.okhttp.Connection.connect(Connection.java:959)
       at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:405)
       at com.android.okhttp.internal.http.HttpEngine.sendSocketRequest(HttpEngine.java:343)
       at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:289)
       at com.android.okhttp.internal.http.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:345)
       at com.android.okhttp.internal.http.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:89)
       at com.android.okhttp.internal.http.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:197)
       at com.android.okhttp.internal.http.HttpsURLConnectionImpl.getOutputStream(HttpsURLConnectionImpl.java:254)
       at com.github.nkzawa.engineio.client.transports.PollingXHR$Request$1.run(PollingXHR.java:205)
       at java.lang.Thread.run(Thread.java:841)
```

so I guess why it occured.

after creating xhr instance, then xhr would start to connect.
but in connecting, network was disconnected. (to diconnect network or to turn off network forcibly)
then HttpConnection in Okhttp was occured NullPointException. because it couldn't find NetworkList. 

so I added tyr-catch ```NullPointException```