### PR TITLE
squid:S00117 - Local variable and method parameter names should comply with a naming convention

### DIFF
--- a/src/main/java/io/socket/emitter/Emitter.java
+++ b/src/main/java/io/socket/emitter/Emitter.java
@@ -29,9 +29,9 @@ public class Emitter {
         ConcurrentLinkedQueue<Listener> callbacks = this.callbacks.get(event);
         if (callbacks == null) {
             callbacks = new ConcurrentLinkedQueue <Listener>();
-            ConcurrentLinkedQueue<Listener> _callbacks = this.callbacks.putIfAbsent(event, callbacks);
-            if (_callbacks != null) {
-                callbacks = _callbacks;
+            ConcurrentLinkedQueue<Listener> tempCallbacks = this.callbacks.putIfAbsent(event, callbacks);
+            if (tempCallbacks != null) {
+                callbacks = tempCallbacks;
             }
         }
         callbacks.add(fn);

--- a/src/main/java/io/socket/engineio/client/HandshakeData.java
+++ b/src/main/java/io/socket/engineio/client/HandshakeData.java
@@ -19,13 +19,13 @@ public class HandshakeData {
     /*package*/ HandshakeData(JSONObject data) throws JSONException {
         JSONArray upgrades = data.getJSONArray("upgrades");
         int length = upgrades.length();
-        String[] _upgrades = new String[length];
+        String[] tempUpgrades = new String[length];
         for (int i = 0; i < length; i ++) {
-            _upgrades[i] = upgrades.getString(i);
+            tempUpgrades[i] = upgrades.getString(i);
         }
 
         this.sid = data.getString("sid");
-        this.upgrades = _upgrades;
+        this.upgrades = tempUpgrades;
         this.pingInterval = data.getLong("pingInterval");
         this.pingTimeout = data.getLong("pingTimeout");
     }

--- a/src/main/java/io/socket/engineio/client/transports/Polling.java
+++ b/src/main/java/io/socket/engineio/client/transports/Polling.java
@@ -128,8 +128,8 @@ abstract public class Polling extends Transport {
 
         if (data instanceof String) {
             @SuppressWarnings("unchecked")
-            Parser.DecodePayloadCallback<String> _callback = callback;
-            Parser.decodePayload((String)data, _callback);
+            Parser.DecodePayloadCallback<String> tempCallback = callback;
+            Parser.decodePayload((String)data, tempCallback);
         } else if (data instanceof byte[]) {
             Parser.decodePayload((byte[])data, callback);
         }
@@ -203,19 +203,19 @@ abstract public class Polling extends Transport {
             query.put(this.timestampParam, Yeast.yeast());
         }
 
-        String _query = ParseQS.encode(query);
+        String derivedQuery = ParseQS.encode(query);
 
         if (this.port > 0 && (("https".equals(schema) && this.port != 443)
                 || ("http".equals(schema) && this.port != 80))) {
             port = ":" + this.port;
         }
 
-        if (_query.length() > 0) {
-            _query = "?" + _query;
+        if (derivedQuery.length() > 0) {
+            derivedQuery = "?" + derivedQuery;
         }
 
         boolean ipv6 = this.hostname.contains(":");
-        return schema + "://" + (ipv6 ? "[" + this.hostname + "]" : this.hostname) + port + this.path + _query;
+        return schema + "://" + (ipv6 ? "[" + this.hostname + "]" : this.hostname) + port + this.path + derivedQuery;
     }
 
     abstract protected void doWrite(byte[] data, Runnable fn);

--- a/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
@@ -281,9 +281,9 @@ public class PollingXHR extends Polling {
                     int len = 0;
                     byte[] buffer = new byte[1024];
                     while ((len = input.read(buffer)) > 0) {
-                        byte[] _buffer = new byte[len];
-                        System.arraycopy(buffer, 0, _buffer, 0, len);
-                        buffers.add(_buffer);
+                        byte[] tempBuffer = new byte[len];
+                        System.arraycopy(buffer, 0, tempBuffer, 0, len);
+                        buffers.add(tempBuffer);
                         capacity += len;
                     }
                     ByteBuffer data = ByteBuffer.allocate(capacity);

--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -221,12 +221,12 @@ public class WebSocket extends Transport {
             query.put(this.timestampParam, Yeast.yeast());
         }
 
-        String _query = ParseQS.encode(query);
-        if (_query.length() > 0) {
-            _query = "?" + _query;
+        String derivedQuery = ParseQS.encode(query);
+        if (derivedQuery.length() > 0) {
+            derivedQuery = "?" + derivedQuery;
         }
 
         boolean ipv6 = this.hostname.contains(":");
-        return schema + "://" + (ipv6 ? "[" + this.hostname + "]" : this.hostname) + port + this.path + _query;
+        return schema + "://" + (ipv6 ? "[" + this.hostname + "]" : this.hostname) + port + this.path + derivedQuery;
     }
 }

--- a/src/main/java/io/socket/engineio/parser/Parser.java
+++ b/src/main/java/io/socket/engineio/parser/Parser.java
@@ -45,10 +45,10 @@ public class Parser {
     public static void encodePacket(Packet packet, boolean utf8encode, EncodeCallback callback) throws UTF8Exception {
         if (packet.data instanceof byte[]) {
             @SuppressWarnings("unchecked")
-            Packet<byte[]> _packet = packet;
+            Packet<byte[]> packetToEncode = packet;
             @SuppressWarnings("unchecked")
-            EncodeCallback<byte[]> _callback = callback;
-            encodeByteArray(_packet, _callback);
+            EncodeCallback<byte[]> callbackToEncode = callback;
+            encodeByteArray(packetToEncode, callbackToEncode);
             return;
         }
 
@@ -59,8 +59,8 @@ public class Parser {
         }
 
         @SuppressWarnings("unchecked")
-        EncodeCallback<String> _callback = callback;
-        _callback.call(encoded);
+        EncodeCallback<String> tempCallback = callback;
+        tempCallback.call(encoded);
     }
 
     private static void encodeByteArray(Packet<byte[]> packet, EncodeCallback<byte[]> callback) {
@@ -219,8 +219,8 @@ public class Parser {
             }
             if (numberTooLong) {
                 @SuppressWarnings("unchecked")
-                DecodePayloadCallback<String> _callback = callback;
-                _callback.call(err, 0, 1);
+                DecodePayloadCallback<String> tempCallback = callback;
+                tempCallback.call(err, 0, 1);
                 return;
             }
             bufferTail.position(strLen.length() + 1);
@@ -247,12 +247,12 @@ public class Parser {
             Object buffer = buffers.get(i);
             if (buffer instanceof String) {
                 @SuppressWarnings("unchecked")
-                DecodePayloadCallback<String> _callback = callback;
-                _callback.call(decodePacket((String)buffer, true), i, total);
+                DecodePayloadCallback<String> tempCallback = callback;
+                tempCallback.call(decodePacket((String)buffer, true), i, total);
             } else if (buffer instanceof byte[]) {
                 @SuppressWarnings("unchecked")
-                DecodePayloadCallback<byte[]> _callback = callback;
-                _callback.call(decodePacket((byte[])buffer), i, total);
+                DecodePayloadCallback<byte[]> tempCallback = callback;
+                tempCallback.call(decodePacket((byte[])buffer), i, total);
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00117
Please let me know if you have any questions.
George Kankava