### PR TITLE
squid:S00122 - Statements should be on separate lines

### DIFF
--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -176,9 +176,13 @@ public class Socket extends Emitter {
             boolean ipv6 = hostname.split(":").length > 2;
             if (ipv6) {
                 int start = hostname.indexOf('[');
-                if (start != -1) hostname = hostname.substring(start + 1);
+                if (start != -1) {
+                    hostname = hostname.substring(start + 1);
+                }
                 int end = hostname.lastIndexOf(']');
-                if (end != -1) hostname = hostname.substring(0, end);
+                if (end != -1) {
+                    hostname = hostname.substring(0, end);
+                }
             }
             opts.hostname = hostname;
         }
@@ -324,7 +328,9 @@ public class Socket extends Emitter {
         final Listener onTransportOpen = new Listener() {
             @Override
             public void call(Object... args) {
-                if (failed[0]) return;
+                if (failed[0]) {
+                    return;
+                }
 
                 logger.fine(String.format("probe transport '%s' opened", name));
                 Packet<String> packet = new Packet<String>(Packet.PING, "probe");
@@ -332,22 +338,30 @@ public class Socket extends Emitter {
                 transport[0].once(Transport.EVENT_PACKET, new Listener() {
                     @Override
                     public void call(Object... args) {
-                        if (failed[0]) return;
+                        if (failed[0]) {
+                            return;
+                        }
 
                         Packet msg = (Packet)args[0];
                         if (Packet.PONG.equals(msg.type) && "probe".equals(msg.data)) {
                             logger.fine(String.format("probe transport '%s' pong", name));
                             self.upgrading = true;
                             self.emit(EVENT_UPGRADING, transport[0]);
-                            if (null == transport[0]) return;
+                            if (null == transport[0]) {
+                                return;
+                            }
                             Socket.priorWebsocketSuccess = WebSocket.NAME.equals(transport[0].name);
 
                             logger.fine(String.format("pausing current transport '%s'", self.transport.name));
                             ((Polling)self.transport).pause(new Runnable() {
                                 @Override
                                 public void run() {
-                                    if (failed[0]) return;
-                                    if (ReadyState.CLOSED == self.readyState) return;
+                                    if (failed[0]) {
+                                        return;
+                                    }
+                                    if (ReadyState.CLOSED == self.readyState) {
+                                        return;
+                                    }
 
                                     logger.fine("changing transport and sending upgrade packet");
 
@@ -376,7 +390,9 @@ public class Socket extends Emitter {
         final Listener freezeTransport = new Listener() {
             @Override
             public void call(Object... args) {
-                if (failed[0]) return;
+                if (failed[0]) {
+                    return;
+                }
 
                 failed[0] = true;
 
@@ -511,7 +527,9 @@ public class Socket extends Emitter {
         this.pingTimeout = data.pingTimeout;
         this.onOpen();
         // In case open handler closes socket
-        if (ReadyState.CLOSED == this.readyState) return;
+        if (ReadyState.CLOSED == this.readyState) {
+            return;
+        }
         this.setPing();
 
         this.off(EVENT_HEARTBEAT, this.onHeartbeatAsListener);
@@ -541,7 +559,9 @@ public class Socket extends Emitter {
                 EventThread.exec(new Runnable() {
                     @Override
                     public void run() {
-                        if (self.readyState == ReadyState.CLOSED) return;
+                        if (self.readyState == ReadyState.CLOSED) {
+                            return;
+                        }
                         self.onClose("ping timeout");
                     }
                 });

--- a/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
@@ -225,7 +225,9 @@ public class PollingXHR extends Polling {
                         self.onError(e);
                     } finally {
                         try {
-                            if (output != null) output.close();
+                            if (output != null) {
+                                output.close();
+                            }
                         } catch (IOException e) {}
                     }
                 }
@@ -304,10 +306,14 @@ public class PollingXHR extends Polling {
                 this.onError(e);
             } finally {
                 try {
-                    if (input != null) input.close();
+                    if (input != null) {
+                        input.close();
+                    }
                 } catch (IOException e) {}
                 try {
-                    if (reader != null) reader.close();
+                    if (reader != null) {
+                        reader.close();
+                    }
                 } catch (IOException e) {}
             }
         }

--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -178,7 +178,9 @@ public class WebSocket extends Transport {
                         logger.fine("websocket closed before onclose event");
                     }
 
-                    if (0 == --total[0]) done.run();
+                    if (0 == --total[0]) {
+                        done.run();
+                    }
                 }
             });
         }

--- a/src/main/java/io/socket/engineio/parser/Parser.java
+++ b/src/main/java/io/socket/engineio/parser/Parser.java
@@ -186,7 +186,9 @@ public class Parser {
                     }
 
                     boolean ret = callback.call(packet, i + n, l);
-                    if (!ret) return;
+                    if (!ret) {
+                        return;
+                    }
                 }
 
                 i += n;
@@ -209,7 +211,9 @@ public class Parser {
             boolean numberTooLong = false;
             for (int i = 1; ; i++) {
                 int b = bufferTail.get(i) & 0xFF;
-                if (b == 255) break;
+                if (b == 255) {
+                    break;
+                }
                 // supports only integer
                 if (strLen.length() > MAX_INT_CHAR_LENGTH) {
                     numberTooLong = true;

--- a/src/main/java/io/socket/parseqs/ParseQS.java
+++ b/src/main/java/io/socket/parseqs/ParseQS.java
@@ -13,7 +13,9 @@ public class ParseQS {
     public static String encode(Map<String, String> obj) {
         StringBuilder str = new StringBuilder();
         for (Map.Entry<String, String> entry : obj.entrySet()) {
-            if (str.length() > 0) str.append("&");
+            if (str.length() > 0) {
+                str.append("&");
+            }
             str.append(Global.encodeURIComponent(entry.getKey())).append("=")
                     .append(Global.encodeURIComponent(entry.getValue()));
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S00122 - Statements should be on separate lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
Please let me know if you have any questions.
George Kankava