### PR TITLE
Multiple code improvements: squid:S1118, squid:S1068

### DIFF
--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -90,11 +90,6 @@ public class Socket extends Emitter {
      */
     public static final String EVENT_TRANSPORT = "transport";
 
-    private static final Runnable noop = new Runnable() {
-        @Override
-        public void run() {}
-    };
-
     /**
      * The protocol version.
      */

--- a/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
@@ -19,9 +19,6 @@ public class PollingXHR extends Polling {
 
     private static final Logger logger = Logger.getLogger(PollingXHR.class.getName());
 
-    private Request sendXhr;
-    private Request pollXhr;
-
     public PollingXHR(Transport.Options opts) {
         super(opts);
     }
@@ -92,7 +89,6 @@ public class PollingXHR extends Polling {
             }
         });
         req.create();
-        this.sendXhr = req;
     }
 
     @Override
@@ -129,7 +125,6 @@ public class PollingXHR extends Polling {
             }
         });
         req.create();
-        this.pollXhr = req;
     }
 
     public static class Request extends Emitter {

--- a/src/main/java/io/socket/utf8/UTF8.java
+++ b/src/main/java/io/socket/utf8/UTF8.java
@@ -8,12 +8,14 @@ import java.util.List;
  *
  * @see <a href="https://github.com/mathiasbynens/utf8.js">https://github.com/mathiasbynens/utf8.js</a>
  */
-public class UTF8 {
+public final class UTF8 {
 
     private static final String INVALID_CONTINUATION_BYTE = "Invalid continuation byte";
     private static int[] byteArray;
     private static int byteCount;
     private static int byteIndex;
+
+    private UTF8 () {}
 
     public static String encode(String string) throws UTF8Exception {
         int[] codePoints = ucs2decode(string);

--- a/src/main/java/io/socket/yeast/Yeast.java
+++ b/src/main/java/io/socket/yeast/Yeast.java
@@ -7,7 +7,7 @@ import java.util.Map;
 /**
  * A Java implementation of yeast. https://github.com/unshiftio/yeast
  */
-public class Yeast {
+public final class Yeast {
     private static char[] alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_".toCharArray();
 
     private static int length = alphabet.length;
@@ -18,6 +18,8 @@ public class Yeast {
             map.put(alphabet[i], i);
         }
     }
+
+    private Yeast () {}
 
     private static int seed = 0;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 -  Utility classes should not have public constructors.
squid:S1068 - Unused private fields should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1068
Please let me know if you have any questions.
George Kankava