### PR TITLE
multiple code improvements: squid:S2293, squid:S1213, squid:S2185, squid:S1905, squid:S1226

### DIFF
--- a/src/main/java/io/socket/yeast/Yeast.java
+++ b/src/main/java/io/socket/yeast/Yeast.java
@@ -11,7 +11,8 @@ public final class Yeast {
     private static char[] alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_".toCharArray();
 
     private static int length = alphabet.length;
-
+    private static int seed = 0;
+    private static String prev;
     private static Map<Character, Integer> map = new HashMap<Character, Integer>(length);
     static {
         for (int i = 0; i < length; i++) {
@@ -21,17 +22,13 @@ public final class Yeast {
 
     private Yeast () {}
 
-    private static int seed = 0;
-
-    private static String prev;
-
     public static String encode(long num) {
         final StringBuilder encoded = new StringBuilder();
-
+        long dividedNum;
         do {
             encoded.insert(0, alphabet[(int)(num % length)]);
-            num = (long)Math.floor(num / length);
-        } while (num > 0);
+            dividedNum = num / length;
+        } while (dividedNum > 0);
 
         return encoded.toString();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order,
squid:S2185 Silly math should not be performed,
squid:S1905 Redundant casts should not be used,
squid:S1226 Method parameters, caught exceptions and foreach variables should not be reassigned.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2185
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1905
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1226
Please let me know if you have any questions.
George Kankava