### PR TITLE
multiple code improvements: squid:S2293, squid:ClassVariableVisibilityCheck

### DIFF
--- a/src/main/java/io/socket/utf8/UTF8Exception.java
+++ b/src/main/java/io/socket/utf8/UTF8Exception.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 public class UTF8Exception extends IOException {
 
-    public String data;
+    private String data;
 
     public UTF8Exception() {
         super();
@@ -20,5 +20,13 @@ public class UTF8Exception extends IOException {
 
     public UTF8Exception(Throwable cause) {
         super(cause);
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:ClassVariableVisibilityCheck Class variable fields should not have public accessibility.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:ClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava
