### PR TITLE
changed EventThread to extend daemon property from parent thread

### DIFF
--- a/src/main/java/io/socket/thread/EventThread.java
+++ b/src/main/java/io/socket/thread/EventThread.java
@@ -20,6 +20,7 @@ public class EventThread extends Thread {
         public Thread newThread(Runnable runnable) {
             thread = new EventThread(runnable);
             thread.setName("EventThread");
+            thread.setDaemon(Thread.currentThread().isDaemon());
             return thread;
         }
     };


### PR DESCRIPTION
EventThread is creating non daemon thread, and there is no way to make it not to...
Default java convention for threads is to extend daemon flag from parent thread (see the jdk code),
this fix is making sure that this behaviour remains when using Socket.io lib in other java apps...