### PR TITLE
Close the web socket after sending a close frame.

### DIFF
--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -190,9 +190,6 @@ public class WebSocket extends Transport {
     }
 
     protected void doClose() {
-        if (wsCall != null) {
-            wsCall.cancel();
-        }
         if (ws != null) {
             try {
                 ws.close(1000, "");
@@ -201,6 +198,9 @@ public class WebSocket extends Transport {
             } catch (IllegalStateException e) {
                 // websocket already closed
             }
+        }
+        if (wsCall != null) {
+            wsCall.cancel();
         }
     }
 


### PR DESCRIPTION
Previously, the underlying socket was being closed with the cancel call.
Because the socket was closed, the close frame could never be sent.