### PR TITLE
[Fix] "must call close()" crash

### DIFF
--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -163,8 +163,13 @@ public class WebSocket extends Transport {
             }
         };
 
-        final int[] total = new int[] { packets.length };
+        final int[] total = new int[]{packets.length};
         for (Packet packet : packets) {
+            if (this.readyState != ReadyState.OPENING && this.readyState != ReadyState.OPEN) {
+                // Ensure we don't try to send anymore packets if the socket ends up being closed due to an exception
+                break;
+            }
+
             Parser.encodePacket(packet, new Parser.EncodeCallback() {
                 @Override
                 public void call(Object packet) {
@@ -176,6 +181,7 @@ public class WebSocket extends Transport {
                         }
                     } catch (IOException e) {
                         logger.fine("websocket closed before onclose event");
+                        close();
                     }
 
                     if (0 == --total[0]) done.run();


### PR DESCRIPTION
Closes the Websocket in case of an IOException (as mentioned in [here](https://github.com/square/okhttp/issues/2630#issuecomment-226402457)).
Fixes #56, https://github.com/socketio/socket.io-client-java/issues/313 and https://github.com/socketio/socket.io-client-java/issues/275