### PR TITLE
fix added to fix following crash

### DIFF
--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -190,6 +190,9 @@ public class WebSocket extends Transport {
                         } else if (packet instanceof byte[]) {
                             self.ws.sendMessage(RequestBody.create(BINARY, (byte[]) packet));
                         }
+                    } catch (IllegalStateException e) {
+                        logger.fine("websocket closed before we could write");
+                        doClose();
                     } catch (IOException e) {
                         logger.fine("websocket closed before onclose event");
                         doClose();

--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -192,7 +192,6 @@ public class WebSocket extends Transport {
                         }
                     } catch (IllegalStateException e) {
                         logger.fine("websocket closed before we could write");
-                        doClose();
                     } catch (IOException e) {
                         logger.fine("websocket closed before onclose event");
                         doClose();


### PR DESCRIPTION
@nkzawa @chendrak this pull request addresses the following issue
https://github.com/socketio/socket.io-client-java/issues/346

Could you please confirm if this is logical thing to do?

Fatal Exception: java.lang.IllegalStateException: closed
       at okhttp3.internal.ws.RealWebSocket.sendMessage(RealWebSocket.java:107)
       at io.socket.engineio.client.transports.WebSocket$4.call(WebSocket.java:189)
       at io.socket.engineio.parser.Parser.encodePacket(Parser.java:63)
       at io.socket.engineio.parser.Parser.encodePacket(Parser.java:42)
       at io.socket.engineio.client.transports.WebSocket.write(WebSocket.java:184)
       at io.socket.engineio.client.Transport$3.run(Transport.java:108)
       at io.socket.thread.EventThread.exec(EventThread.java:55)
       at io.socket.engineio.client.Transport.send(Transport.java:103)
       at io.socket.engineio.client.Socket.flush(Socket.java:615)
       at io.socket.engineio.client.Socket.onDrain(Socket.java:606)
       at io.socket.engineio.client.Socket.access$1100(Socket.java:31)
       at io.socket.engineio.client.Socket$6.call(Socket.java:308)
       at io.socket.emitter.Emitter.emit(Emitter.java:117)
       at io.socket.engineio.client.transports.WebSocket$3$1.run(WebSocket.java:171)
       at io.socket.thread.EventThread$2.run(EventThread.java:80)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)


Indirect Replication Steps:
This bug happens a lot in wild. Typical reason is that, the socket is "sometimes" closed, just when the client was about to write something on it.

If you forcefully close the socket (by calling doClose()) just before the execution of this line (https://github.com/socketio/engine.io-client-java/blob/master/src/main/java/io/socket/engineio/client/transports/WebSocket.java#L189) then it will crash giving out IllegalStateException at the very next moment! But if you add this fix, it won't crash at this place.