### PR TITLE
add websocket transport ping.

### DIFF
--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -590,6 +590,10 @@ public class Socket extends Emitter {
                         Socket.this.emit(EVENT_PING);
                     }
                 });
+
+              if (transport != null && transport instanceof WebSocket) {
+                  ((WebSocket)transport).doPing();
+              }
             }
         });
     }

--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -203,6 +203,20 @@ public class WebSocket extends Transport {
         }
     }
 
+    /**
+     * websocket impl need to call ping periodically,
+     * see this: https://github.com/square/okhttp/issues/1985
+     */
+    public void doPing() {
+      if (ws != null) {
+          try {
+              ws.sendPing(null);
+          } catch (IOException e) {
+              e.printStackTrace();
+          }
+      }
+    }
+
     @Override
     protected void onClose() {
         super.onClose();


### PR DESCRIPTION
according to this okhttp-ws [issue](https://github.com/square/okhttp/issues/1985), the websocket implementation of transport need to call WebsocketCall.sendPing() periodically.