### PR TITLE
add a keepCookies option to presever cookies across XHR requests

### DIFF
--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -127,6 +127,7 @@ public class Socket extends Emitter {
     public Proxy proxy;
     public String proxyLogin;
     public String proxyPassword;
+    public boolean keepCookies;
 
     private ReadyState readyState;
     private ScheduledExecutorService heartbeatScheduler;
@@ -207,6 +208,7 @@ public class Socket extends Emitter {
         this.proxy = opts.proxy;
         this.proxyLogin = opts.proxyLogin;
         this.proxyPassword = opts.proxyPassword;
+        this.keepCookies = opts.keepCookies;
     }
 
     public static void setDefaultSSLContext(SSLContext sslContext) {
@@ -276,6 +278,7 @@ public class Socket extends Emitter {
         opts.proxy = this.proxy;
         opts.proxyLogin = this.proxyLogin;
         opts.proxyPassword = this.proxyPassword;
+        opts.keepCookies = this.keepCookies;
 
         Transport transport;
         if (WebSocket.NAME.equals(name)) {

--- a/src/main/java/io/socket/engineio/client/Transport.java
+++ b/src/main/java/io/socket/engineio/client/Transport.java
@@ -162,5 +162,6 @@ public abstract class Transport extends Emitter {
         public Proxy proxy;
         public String proxyLogin;
         public String proxyPassword;
+        public boolean keepCookies;
     }
 }


### PR DESCRIPTION
Hi,

I am using the java socket io client to test a service running behind an aws application load balancer. The ALB uses cookies to implement sticky sessions. This code adds a "keepCookies" option and code to support it. When keepCookies is true (defaults to false) PollingXHR will save any cookies the server sets and send them back.

I didn't see a way to easily test this with the existing test harness. I am open to suggestions. 