### PR TITLE
Add option to share OkHttpClient

### DIFF
--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -850,7 +850,6 @@ public class Socket extends Emitter {
     public static class Options extends Transport.Options {
 
         public boolean shareOkHttpClient = false;
-        public Transport.storeOkHttpClient storeOkHttpClient = null;
 
         /**
          * List of transport names.

--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -101,6 +101,7 @@ public class Socket extends Emitter {
     private static SSLContext defaultSSLContext;
     private static HostnameVerifier defaultHostnameVerifier;
 
+    private Transport.storeOkHttpClient storeOkHttpClient = null;
     private boolean secure;
     private boolean upgrade;
     private boolean timestampRequests;
@@ -190,6 +191,10 @@ public class Socket extends Emitter {
             opts.port = this.secure ? 443 : 80;
         }
 
+        if (opts.shareOkHttpClient && opts.storeOkHttpClient == null) {
+            opts.storeOkHttpClient = new Transport.storeOkHttpClient();
+        }
+        this.storeOkHttpClient = opts.storeOkHttpClient;
         this.sslContext = opts.sslContext != null ? opts.sslContext : defaultSSLContext;
         this.hostname = opts.hostname != null ? opts.hostname : "localhost";
         this.port = opts.port;
@@ -262,6 +267,7 @@ public class Socket extends Emitter {
         }
 
         Transport.Options opts = new Transport.Options();
+        opts.storeOkHttpClient = this.storeOkHttpClient;
         opts.sslContext = this.sslContext;
         opts.hostname = this.hostname;
         opts.port = this.port;
@@ -842,6 +848,9 @@ public class Socket extends Emitter {
     }
 
     public static class Options extends Transport.Options {
+
+        public boolean shareOkHttpClient = false;
+        public Transport.storeOkHttpClient storeOkHttpClient = null;
 
         /**
          * List of transport names.

--- a/src/main/java/io/socket/engineio/client/Transport.java
+++ b/src/main/java/io/socket/engineio/client/Transport.java
@@ -11,6 +11,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.net.Proxy;
 import java.util.Map;
+import okhttp3.OkHttpClient;
 
 public abstract class Transport extends Emitter {
 
@@ -47,6 +48,7 @@ public abstract class Transport extends Emitter {
     protected Proxy proxy;
     protected String proxyLogin;
     protected String proxyPassword;
+    protected storeOkHttpClient storeOkHttpClient;
 
     protected ReadyState readyState;
 
@@ -64,6 +66,7 @@ public abstract class Transport extends Emitter {
         this.proxy = opts.proxy;
         this.proxyLogin = opts.proxyLogin;
         this.proxyPassword = opts.proxyPassword;
+        this.storeOkHttpClient = opts.storeOkHttpClient;
     }
 
     protected Transport onError(String msg, Exception desc) {
@@ -148,6 +151,7 @@ public abstract class Transport extends Emitter {
 
     public static class Options {
 
+        public storeOkHttpClient storeOkHttpClient = null;
         public String hostname;
         public String path;
         public String timestampParam;
@@ -162,5 +166,11 @@ public abstract class Transport extends Emitter {
         public Proxy proxy;
         public String proxyLogin;
         public String proxyPassword;
+    }
+
+    public static class storeOkHttpClient {
+
+        public OkHttpClient.Builder OkHttpClientBuilder = null;
+
     }
 }

--- a/src/main/java/io/socket/engineio/client/Transport.java
+++ b/src/main/java/io/socket/engineio/client/Transport.java
@@ -171,6 +171,5 @@ public abstract class Transport extends Emitter {
     public static class storeOkHttpClient {
 
         public OkHttpClient.Builder OkHttpClientBuilder = null;
-
     }
 }

--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -149,7 +149,9 @@ public class WebSocket extends Transport {
                 });
             }
         });
-        //client.dispatcher().executorService().shutdown();
+        if (this.storeOkHttpClient == null || this.storeOkHttpClient.OkHttpClientBuilder == null) {
+            client.dispatcher().executorService().shutdown();
+        }
     }
 
     protected void write(Packet[] packets) throws UTF8Exception {

--- a/src/main/java/io/socket/engineio/client/transports/WebSocket.java
+++ b/src/main/java/io/socket/engineio/client/transports/WebSocket.java
@@ -39,11 +39,23 @@ public class WebSocket extends Transport {
         this.emit(EVENT_REQUEST_HEADERS, headers);
 
         final WebSocket self = this;
-        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
-                // turn off timeouts (github.com/socketio/engine.io-client-java/issues/32)
-                .connectTimeout(0, TimeUnit.MILLISECONDS)
-                .readTimeout(0, TimeUnit.MILLISECONDS)
-                .writeTimeout(0, TimeUnit.MILLISECONDS);
+        OkHttpClient.Builder clientBuilder;
+        if (this.storeOkHttpClient != null) {
+            if (this.storeOkHttpClient.OkHttpClientBuilder == null) {
+                this.storeOkHttpClient.OkHttpClientBuilder = new OkHttpClient.Builder()
+                        // turn off timeouts (github.com/socketio/engine.io-client-java/issues/32)
+                        .connectTimeout(0, TimeUnit.MILLISECONDS)
+                        .readTimeout(0, TimeUnit.MILLISECONDS)
+                        .writeTimeout(0, TimeUnit.MILLISECONDS);
+            }
+            clientBuilder = this.storeOkHttpClient.OkHttpClientBuilder;
+        } else {
+            clientBuilder = new OkHttpClient.Builder()
+                    // turn off timeouts (github.com/socketio/engine.io-client-java/issues/32)
+                    .connectTimeout(0, TimeUnit.MILLISECONDS)
+                    .readTimeout(0, TimeUnit.MILLISECONDS)
+                    .writeTimeout(0, TimeUnit.MILLISECONDS);
+        }
 
         if (this.sslContext != null) {
             SSLSocketFactory factory = sslContext.getSocketFactory();// (SSLSocketFactory) SSLSocketFactory.getDefault();
@@ -137,7 +149,7 @@ public class WebSocket extends Transport {
                 });
             }
         });
-        client.dispatcher().executorService().shutdown();
+        //client.dispatcher().executorService().shutdown();
     }
 
     protected void write(Packet[] packets) throws UTF8Exception {


### PR DESCRIPTION
Potentially Fixes Issue #81

This adds an option to share an OkHttpClient instance over multiple sockets (from reconnect attempts, and etc). Defaults to false.
Let me know if the option can be named better, or if this can be done a better way.
This java-client-specific option can probably be mentioned in the readme under features?