### PR TITLE
Options for inject okhttp Call/WebSocket factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,19 @@ socket.on(Socket.EVENT_OPEN, new Emitter.Listener() {
 Use custom SSL settings:
 
 ```java
+OkHttpClient okHttpClient = new OkHttpClient.Builder()
+    .hostnameVerifier(myHostnameVerifier)
+    .sslSocketFactory(mySSLContext.getSocketFactory(), myX509TrustManager)
+    .build();
+
 // default SSLContext for all sockets
-Socket.setDefaultSSLContext(mySSLContext);
-Socket.setDefaultHostnameVerifier(myHostnameVerifier);
+Socket.setDefaultOkHttpWebSocketFactory(okHttpClient);
+Socket.setDefaultOkHttpCallFactory(okHttpClient);
 
 // set as an option
 opts = new Socket.Options();
-opts.sslContext = mySSLContext;
-opts.hostnameVerifier = myHostnameVerifier;
+opts.callFactory = okHttpClient;
+opts.webSocketFactory = okHttpClient;
 socket = new Socket(opts);
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.5.0</version>
+      <version>3.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/src/main/java/io/socket/engineio/client/Transport.java
+++ b/src/main/java/io/socket/engineio/client/Transport.java
@@ -1,16 +1,15 @@
 package io.socket.engineio.client;
 
 
+import java.util.Map;
+
 import io.socket.emitter.Emitter;
 import io.socket.engineio.parser.Packet;
 import io.socket.engineio.parser.Parser;
 import io.socket.thread.EventThread;
 import io.socket.utf8.UTF8Exception;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import java.net.Proxy;
-import java.util.Map;
+import okhttp3.Call;
+import okhttp3.WebSocket;
 
 public abstract class Transport extends Emitter {
 
@@ -41,14 +40,10 @@ public abstract class Transport extends Emitter {
     protected String path;
     protected String hostname;
     protected String timestampParam;
-    protected SSLContext sslContext;
     protected Socket socket;
-    protected HostnameVerifier hostnameVerifier;
-    protected Proxy proxy;
-    protected String proxyLogin;
-    protected String proxyPassword;
-
     protected ReadyState readyState;
+    protected WebSocket.Factory webSocketFactory;
+    protected Call.Factory callFactory;
 
     public Transport(Options opts) {
         this.path = opts.path;
@@ -58,12 +53,9 @@ public abstract class Transport extends Emitter {
         this.query = opts.query;
         this.timestampParam = opts.timestampParam;
         this.timestampRequests = opts.timestampRequests;
-        this.sslContext = opts.sslContext;
         this.socket = opts.socket;
-        this.hostnameVerifier = opts.hostnameVerifier;
-        this.proxy = opts.proxy;
-        this.proxyLogin = opts.proxyLogin;
-        this.proxyPassword = opts.proxyPassword;
+        this.webSocketFactory = opts.webSocketFactory;
+        this.callFactory = opts.callFactory;
     }
 
     protected Transport onError(String msg, Exception desc) {
@@ -156,11 +148,8 @@ public abstract class Transport extends Emitter {
         public int port = -1;
         public int policyPort = -1;
         public Map<String, String> query;
-        public SSLContext sslContext;
-        public HostnameVerifier hostnameVerifier;
         protected Socket socket;
-        public Proxy proxy;
-        public String proxyLogin;
-        public String proxyPassword;
+        public WebSocket.Factory webSocketFactory;
+        public Call.Factory callFactory;
     }
 }

--- a/src/test/java/io/socket/engineio/client/ExecutionTest.java
+++ b/src/test/java/io/socket/engineio/client/ExecutionTest.java
@@ -17,7 +17,7 @@ public class ExecutionTest extends Connection {
 
     private static final Logger logger = Logger.getLogger(Socket.class.getName());
 
-    final static int TIMEOUT = 30 * 1000;
+    final static int TIMEOUT = 100 * 1000;
 
     @Test(timeout = TIMEOUT)
     public void execConnection() throws InterruptedException, IOException {

--- a/src/test/java/io/socket/engineio/client/ServerConnectionTest.java
+++ b/src/test/java/io/socket/engineio/client/ServerConnectionTest.java
@@ -163,8 +163,8 @@ public class ServerConnectionTest extends Connection {
         });
         socket.open();
 
-        assertThat(messages.take(), is("foo"));
         assertThat(messages.take(), is("hi"));
+        assertThat(messages.take(), is("foo"));
         socket.close();
     }
 


### PR DESCRIPTION
http://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html
>OkHttpClients should be shared

#81 
Now the library could inject the implementation of [Call.Factory](http://square.github.io/okhttp/3.x/okhttp/okhttp3/Call.Factory.html)/[WebSocket.Factory](http://square.github.io/okhttp/3.x/okhttp/okhttp3/WebSocket.Factory.html), usually they are the singleton of [OkHttpClient](http://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html) instance. You could have your own factory implementation, which means that doesn't have to be `OkHttpClient`! Such as a mock implementation.
Attributes in Options such as `hostnameVerifier`, `proxy`, `SSLContext`, `proxyLogin` `proxyPassword` please set directly into OkHttpClient, and there are more attributes you could setup in OkHttpClient, please take a look.