### PR TITLE
update for engine.io-client 1.8.4

### DIFF
--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -496,7 +496,9 @@ public class Socket extends Emitter {
     }
 
     private void onPacket(Packet packet) {
-        if (this.readyState == ReadyState.OPENING || this.readyState == ReadyState.OPEN) {
+        if (this.readyState == ReadyState.OPENING ||
+                this.readyState == ReadyState.OPEN ||
+                this.readyState == ReadyState.CLOSING) {
             logger.fine(String.format("socket received: type '%s', data '%s'", packet.type, packet.data));
 
             this.emit(EVENT_PACKET, packet);

--- a/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
@@ -167,6 +167,8 @@ public class PollingXHR extends Polling {
                 headers.put("Content-type", new LinkedList<String>(Collections.singletonList(BINARY_CONTENT_TYPE)));
             }
 
+            headers.put("Accept", new LinkedList<String>(Collections.singletonList("*/*")));
+
             self.onRequestHeaders(headers);
 
             logger.fine(String.format("sending xhr with url %s | data %s", this.uri, Arrays.toString(this.data)));

--- a/src/main/java/io/socket/engineio/parser/Parser.java
+++ b/src/main/java/io/socket/engineio/parser/Parser.java
@@ -76,6 +76,10 @@ public class Parser {
     }
 
     public static Packet<String> decodePacket(String data, boolean utf8decode) {
+        if (data == null) {
+            return err;
+        }
+
         int type;
         try {
             type = Character.getNumericValue(data.charAt(0));

--- a/src/test/java/io/socket/engineio/parser/ParserTest.java
+++ b/src/test/java/io/socket/engineio/parser/ParserTest.java
@@ -157,6 +157,13 @@ public class ParserTest {
     }
 
     @Test
+    public void decodeEmptyPayload() {
+        Packet<String> p = decodePacket((String)null);
+        assertThat(p.type, is(Packet.ERROR));
+        assertThat(p.data, is(ERROR_DATA));
+    }
+
+    @Test
     public void decodeBadFormat() {
         Packet<String> p = decodePacket(":::");
         assertThat(p.type, is(Packet.ERROR));

--- a/src/test/resources/package-lock.json
+++ b/src/test/resources/package-lock.json
@@ -1,0 +1,136 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "arraybuffer.slice": {
+      "version": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+    },
+    "blob": {
+      "version": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "engine.io": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz",
+      "integrity": "sha1-d7zhK4Dl1gQpM3/sOw2vaR68kAM=",
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "ws": "1.1.4"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+          "requires": {
+            "mime-types": "2.1.15",
+            "negotiator": "0.6.1"
+          }
+        },
+        "after": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+          "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+        },
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+        },
+        "base64id": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+          "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "engine.io-parser": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+          "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
+          "requires": {
+            "after": "0.8.2",
+            "arraybuffer.slice": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+            "base64-arraybuffer": "0.1.5",
+            "blob": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+            "has-binary": "0.1.7",
+            "wtf-8": "1.0.0"
+          }
+        },
+        "has-binary": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+          "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
+        "ws": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
+          "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
+          "requires": {
+            "options": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+            "ultron": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+          }
+        }
+      }
+    },
+    "isarray": {
+      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "options": {
+      "version": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "ultron": {
+      "version": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "wtf-8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
+    }
+  }
+}

--- a/src/test/resources/package.json
+++ b/src/test/resources/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "engine.io": "1.6.11"
+    "engine.io": "1.8.4"
   }
 }


### PR DESCRIPTION
Adds some fixes which are introduced on ~engine.io-client 1.8.4 (node client) which is used on the latest version of socket.io-client 1.x.

Note: we don't add `localAddress` option and `requestTimeout` option here since they are practically supported by https://github.com/socketio/engine.io-client-java/pull/85 .