### PR TITLE
fix NullPointerException when response doesn't have content type

### DIFF
--- a/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/io/socket/engineio/client/transports/PollingXHR.java
@@ -268,9 +268,9 @@ public class PollingXHR extends Polling {
 
         private void onLoad() {
             ResponseBody body = response.body();
-            String contentType = body.contentType().toString();
 
             try {
+                String contentType = getContentTypeFromBody(body);
                 if (BINARY_CONTENT_TYPE.equalsIgnoreCase(contentType)) {
                     this.onData(body.bytes());
                 } else {
@@ -279,6 +279,14 @@ public class PollingXHR extends Polling {
             } catch (IOException e) {
                 this.onError(e);
             }
+        }
+
+        private String getContentTypeFromBody(ResponseBody body) {
+            MediaType mediaType = body.contentType();
+            if (mediaType == null) {
+                return "";
+            }
+            return mediaType.toString();
         }
 
         public static class Options {


### PR DESCRIPTION
This fixes NullPointerException when response doesn't have content type. Exception stack trace:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String okhttp3.MediaType.toString()' on a null object reference
        at io.socket.engineio.client.transports.PollingXHR$Request.onLoad(PollingXHR.java:271)
        at io.socket.engineio.client.transports.PollingXHR$Request.access$700(PollingXHR.java:148)
        at io.socket.engineio.client.transports.PollingXHR$Request$1.onResponse(PollingXHR.java:232)
        at okhttp3.RealCall$AsyncCall.execute(RealCall.java:141)
        at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
        at java.lang.Thread.run(Thread.java:764)
```