### PR TITLE
Upgrade to OkHttp 4.10.0, fixes #112

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.12.12</version>
+      <version>4.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>


### PR DESCRIPTION
OkHttp 3 and 4 are supposed to be fairly compatible according to OkHttp themselves. I do see some SocketException entries when running the tests. The test go green however and I've intercepted some of the tests to make sure that the test is not flakey with good results.

I'm still new to this project though so be critical.

**References:**
https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4/