### PR TITLE
Add volatile socket support to SocketIO client

### DIFF
--- a/src/main/java/io/socket/engineio/client/Socket.java
+++ b/src/main/java/io/socket/engineio/client/Socket.java
@@ -844,6 +844,14 @@ public class Socket extends Emitter {
         return this.id;
     }
 
+    /**
+     * Check transport writability
+     *
+     * @return true if transport is available and writable
+     */
+    public boolean checkTransportWritable() {
+        return transport != null && transport.writable;
+    }
     private ScheduledExecutorService getHeartbeatScheduler() {
         if (this.heartbeatScheduler == null || this.heartbeatScheduler.isShutdown()) {
             this.heartbeatScheduler = createHeartbeatScheduler();


### PR DESCRIPTION
In order to [add volatile socket support](https://github.com/socketio/socket.io-client/commit/7ddad2c09dea0391b20378ef03b40040f0230d3e) to [Socket.IO-client Java](https://github.com/socketio/socket.io-client-java). We need to check if the transport we use in the socket is writable or not. I added a getter method for it in order to use it in the implementation of the feature in [Socket.IO-client Java](https://github.com/socketio/socket.io-client-java)